### PR TITLE
fix(worldbook): 修复继续生成后世界书白屏 (content 字段缺失)

### DIFF
--- a/src/renderer/views/WorldBookEditor.vue
+++ b/src/renderer/views/WorldBookEditor.vue
@@ -153,7 +153,7 @@
             <!-- 预览模式 -->
             <pre v-else class="ai-result-item__content selectable">{{ result.content }}</pre>
             <div class="ai-result-item__meta">
-              {{ result.position }} | order {{ result.insertion_order }} | {{ result.content.length }} 字符
+              {{ result.position }} | order {{ result.insertion_order }} | {{ (result.content || '').length }} 字符
             </div>
           </div>
         </div>
@@ -749,6 +749,8 @@ ${baseInstruction}`;
         const newItems = parsed.map(item => ({
           ...item,
           selected: true,
+          comment: item.comment || '未命名条目',
+          content: item.content || '',
           keys: item.keys || [],
           constant: item.constant ?? false,
           position: item.position || 'before_char',
@@ -792,7 +794,7 @@ async function regenNovelResult(index) {
     const match = cleaned.match(/\{[\s\S]*\}/);
     if (!match) throw new Error('AI 返回格式异常');
     const parsed = JSON.parse(match[0]);
-    novelResults.value[index] = { ...parsed, selected: true, keys: parsed.keys || old.keys, constant: parsed.constant ?? old.constant, position: parsed.position || 'before_char', insertion_order: parsed.insertion_order || 100 };
+    novelResults.value[index] = { ...parsed, selected: true, comment: parsed.comment || old.comment || '未命名条目', content: parsed.content ?? old.content ?? '', keys: parsed.keys || old.keys, constant: parsed.constant ?? old.constant, position: parsed.position || 'before_char', insertion_order: parsed.insertion_order || 100 };
     appStore.toastSuccess(`「${parsed.comment || old.comment}」已重新生成`);
   } catch (e) {
     appStore.toastError('重新生成失败: ' + e.message);
@@ -827,6 +829,8 @@ ${novelExtra.value ? '【额外要求】\n' + novelExtra.value + '\n' : ''}
 
     const newItems = parsed.map(item => ({
       ...item, selected: true,
+      comment: item.comment || '未命名条目',
+      content: item.content || '',
       keys: item.keys || [], constant: item.constant ?? false,
       position: item.position || 'before_char', insertion_order: item.insertion_order || 100
     }));
@@ -973,6 +977,8 @@ ${aiWorldDesc.value}
           const newItems = parsed.map(item => ({
             ...item,
             selected: true,
+            comment: item.comment || '未命名条目',
+            content: item.content || '',
             keys: item.keys || [],
             constant: item.constant ?? false,
             position: item.position || 'before_char',
@@ -1029,6 +1035,8 @@ ${cardContext}
     aiResults.value[index] = {
       ...parsed,
       selected: true,
+      comment: parsed.comment || old.comment || '未命名条目',
+      content: parsed.content ?? old.content ?? '',
       keys: parsed.keys || old.keys,
       constant: parsed.constant ?? old.constant,
       position: parsed.position || old.position,
@@ -1064,6 +1072,8 @@ ${aiWorldDesc.value}
       { role: 'user', content: prompt }
     ], { temperature: 0.7, maxTokens: apiStore.getModelMaxTokens(apiStore.activeProvider?.model) })).map(item => ({
       ...item, selected: true,
+      comment: item.comment || '未命名条目',
+      content: item.content || '',
       keys: item.keys || [], constant: item.constant ?? false,
       position: item.position || 'before_char', insertion_order: item.insertion_order || 100
     }));

--- a/web/src/views/WorldBookEditor.vue
+++ b/web/src/views/WorldBookEditor.vue
@@ -153,7 +153,7 @@
             <!-- 预览模式 -->
             <pre v-else class="ai-result-item__content selectable">{{ result.content }}</pre>
             <div class="ai-result-item__meta">
-              {{ result.position }} | order {{ result.insertion_order }} | {{ result.content.length }} 字符
+              {{ result.position }} | order {{ result.insertion_order }} | {{ (result.content || '').length }} 字符
             </div>
           </div>
         </div>
@@ -749,6 +749,8 @@ ${baseInstruction}`;
         const newItems = parsed.map(item => ({
           ...item,
           selected: true,
+          comment: item.comment || '未命名条目',
+          content: item.content || '',
           keys: item.keys || [],
           constant: item.constant ?? false,
           position: item.position || 'before_char',
@@ -792,7 +794,7 @@ async function regenNovelResult(index) {
     const match = cleaned.match(/\{[\s\S]*\}/);
     if (!match) throw new Error('AI 返回格式异常');
     const parsed = JSON.parse(match[0]);
-    novelResults.value[index] = { ...parsed, selected: true, keys: parsed.keys || old.keys, constant: parsed.constant ?? old.constant, position: parsed.position || 'before_char', insertion_order: parsed.insertion_order || 100 };
+    novelResults.value[index] = { ...parsed, selected: true, comment: parsed.comment || old.comment || '未命名条目', content: parsed.content ?? old.content ?? '', keys: parsed.keys || old.keys, constant: parsed.constant ?? old.constant, position: parsed.position || 'before_char', insertion_order: parsed.insertion_order || 100 };
     appStore.toastSuccess(`「${parsed.comment || old.comment}」已重新生成`);
   } catch (e) {
     appStore.toastError('重新生成失败: ' + e.message);
@@ -827,6 +829,8 @@ ${novelExtra.value ? '【额外要求】\n' + novelExtra.value + '\n' : ''}
 
     const newItems = parsed.map(item => ({
       ...item, selected: true,
+      comment: item.comment || '未命名条目',
+      content: item.content || '',
       keys: item.keys || [], constant: item.constant ?? false,
       position: item.position || 'before_char', insertion_order: item.insertion_order || 100
     }));
@@ -973,6 +977,8 @@ ${aiWorldDesc.value}
           const newItems = parsed.map(item => ({
             ...item,
             selected: true,
+            comment: item.comment || '未命名条目',
+            content: item.content || '',
             keys: item.keys || [],
             constant: item.constant ?? false,
             position: item.position || 'before_char',
@@ -1029,6 +1035,8 @@ ${cardContext}
     aiResults.value[index] = {
       ...parsed,
       selected: true,
+      comment: parsed.comment || old.comment || '未命名条目',
+      content: parsed.content ?? old.content ?? '',
       keys: parsed.keys || old.keys,
       constant: parsed.constant ?? old.constant,
       position: parsed.position || old.position,
@@ -1064,6 +1072,8 @@ ${aiWorldDesc.value}
       { role: 'user', content: prompt }
     ], { temperature: 0.7, maxTokens: apiStore.getModelMaxTokens(apiStore.activeProvider?.model) })).map(item => ({
       ...item, selected: true,
+      comment: item.comment || '未命名条目',
+      content: item.content || '',
       keys: item.keys || [], constant: item.constant ?? false,
       position: item.position || 'before_char', insertion_order: item.insertion_order || 100
     }));


### PR DESCRIPTION
Hi Anastasia2372, 我是 Martin（他朋友），帮忙定位并修复了这个白屏 bug。

## 🐛 你遇到的问题（对号入座）

- 世界书 → AI 生成条目 → 按"继续生成" → 整个世界书页面变空白
- 切到其他 tab 再切回来 → 还是白
- 错误日志高频出现：`Cannot read properties of undefined (reading 'length')` at `r.activate`
- 分批生成第 3/4 批经常伴随 `JSON at position ~108` 解析失败

## 🔍 根本原因

**不是 keep-alive 的锅，也不是异步时序的锅，是数据源字段缺失。**

模板 `src/renderer/views/WorldBookEditor.vue` 第 156 行：

\`\`\`vue
{{ result.position }} | order {{ result.insertion_order }} | {{ result.content.length }} 字符
\`\`\`

这里读了 \`result.content.length\`。但是六个 AI 结果映射函数里 —— \`handleAiGenerate\` / \`continueGenerate\` / \`regenSingleResult\` / \`generateFromNovel\` / \`continueNovelGenerate\` / \`regenNovelResult\` —— 只给 \`keys/constant/position/insertion_order\` 做了兜底：

\`\`\`js
const newItems = parsed.map(item => ({
  ...item,
  selected: true,
  keys: item.keys || [],          // ✓ 兜底
  constant: item.constant ?? false, // ✓ 兜底
  position: item.position || 'before_char', // ✓ 兜底
  insertion_order: item.insertion_order || 100 // ✓ 兜底
  // ❌ content 没兜底
  // ❌ comment 没兜底
}));
\`\`\`

**偏偏 \`content\` 和 \`comment\` 是 AI 截断时最容易丢的字段**（截断时往往最后一个对象只写到一半就断了，content 字段还没输出来）。

故障链：
1. AI 返回被 maxTokens 截断 → 某条对象缺 \`content\`
2. 未兜底就 push 进 \`aiResults\`
3. 模板渲染读 \`undefined.length\` → Vue 抛错
4. 组件树卸载 → 因为 \`router-view\` 加了 \`keep-alive\` 缓存住崩溃态 → **永久白屏**，切页面回来还是白

## ✅ 修复

**两处改动，每个文件 7 个 diff 点：**

1. **模板防御**：\`{{ result.content.length }}\` → \`{{ (result.content || '').length }}\`
2. **六个映射函数**全部补上：
   \`\`\`js
   comment: item.comment || '未命名条目',
   content: item.content || '',
   \`\`\`

桌面版 (\`src/renderer/views/WorldBookEditor.vue\`) 和网页版 (\`web/src/views/WorldBookEditor.vue\`) 同步修复。

## 🛡️ 改动承诺（很重要）

- ❌ 没加任何新依赖
- ❌ 没改 package.json / vite.config.js / electron-builder 配置 / 发版脚本
- ❌ 没动主进程 (src/main/)、IPC、store
- ❌ 没有一行删除，全是加字段
- ✅ 只改了两个 Vue 文件，共 +24 / -4 行

diff 可以一行一行看，每一处加的都只是 \`content: item.content || ''\` 这类兜底默认值。

## 🧪 验证清单

合并后先不发版，本地跑一遍：

\`\`\`bash
npx vite build
CSC_IDENTITY_AUTO_DISCOVERY=false npx electron-builder --win --x64 --publish never
cp -rf dist_electron/win-unpacked/* ./
\`\`\`

然后测：

- [ ] 世界书 → AI 生成条目 → 正常生成，不白屏
- [ ] 点"继续生成更多"几次 → 不白屏
- [ ] 切到其他 tab 再切回世界书 → 不白屏（验证 keep-alive 不再缓存崩溃态）
- [ ] 某条结果点"重新生成" → 不白屏
- [ ] 小说转世界书 → 生成 → 继续生成 → 不白屏

都过了再走你原本的发版流程（v7 Release + latest.yml + blockmap）。

## 📝 题外话

日志里还有个独立问题：\`Expected ',' or ']' after array element in JSON at position 108\` 是 AI 响应被 maxTokens 砍断，还有 \`No capacity available for gemini-3.1-pro-preview\` 是 provider 限流。**这俩不是代码 bug**，不用动，换个模型或等等就好。

有问题直接评论，Martin 继续帮你看。