### PR TITLE
fix(ui): 侧栏版本号改为动态读取，不再硬编码 v5.0

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -26,7 +26,7 @@
         <div class="sidebar__logo">
           <div class="sidebar__logo-text" style="font-size:15px">
             角色卡锻造炉
-            <span class="sub">v5.0</span>
+            <span class="sub">{{ appVersion }}</span>
           </div>
         </div>
 
@@ -255,6 +255,9 @@ const niangStore = useAiNiangStore();
 // 错误日志弹窗
 const showErrorLog = ref(false);
 
+// 应用版本号（从 package.json 动态读取，避免硬编码）
+const appVersion = ref('');
+
 // 检查更新
 const checkingUpdate = ref(false);
 async function checkUpdate() {
@@ -447,5 +450,9 @@ onMounted(async () => {
   await apiStore.loadFromDisk();
   await loadDrawerHistoryFromDisk();
   window.addEventListener('beforeunload', () => { saveDrawerToHistory(); });
+  try {
+    const v = await window.cardForgeAPI?.getAppVersion?.();
+    if (v) appVersion.value = 'v' + v;
+  } catch (e) { /* 网页版或 preload 异常时静默 */ }
 });
 </script>


### PR DESCRIPTION
Hi Anastasia2372，Martin 又来了。

## 🐛 你困惑的那个"版本号改不了"的问题

你说"改版本到 7.0 不知道为什么当时出了问题，而且软件界面上的版本号也不自动更新了"—— 我查了，其实：

**autoUpdater 和版本号逻辑完全正确**，你每次改 \`package.json\` 的 version 都生效了。问题就一个：

\`src/renderer/App.vue\` 第 29 行写死了：

\`\`\`vue
<span class=\"sub\">v5.0</span>
\`\`\`

**全项目只有这一行硬编码版本号，而且从 v5 发布后就一直没人改过它**。所以你从 v5 → v6 → v7 过程中，侧栏 logo 下那个小字一直是 \"v5.0\"，让你以为版本号没升上去。

其实你的 autoUpdater、electron-builder、latest.yml 三件套里面读的都是 \`package.json\` 的真实版本号（\`app.getVersion()\`），版本升级机制本身是正常的。

## ✅ 修复（8 行代码）

1. 模板：\`<span class=\"sub\">v5.0</span>\` → \`<span class=\"sub\">{{ appVersion }}</span>\`
2. script 里：加 \`const appVersion = ref('')\`
3. \`onMounted\` 里：\`appVersion.value = 'v' + await window.cardForgeAPI.getAppVersion()\`

这三处改动之后，**以后你升版本号只改 \`package.json\` 就行，UI 自动跟随**，再也不用记着同步改这个字符串。

preload 里 \`getAppVersion\` → IPC \`update:getVersion\` → \`app.getVersion()\` 这条链你之前就搭好了，我只是把 UI 接进来而已。

## 🛡️ 改动承诺

- ❌ 没改 package.json / 没改 preload / 没改 main 进程
- ❌ 没改 autoUpdater 任何逻辑
- ❌ 没动其他任何文件
- ✅ 只改了 \`src/renderer/App.vue\` 一个文件，+8 / -1 行
- ✅ 加了 optional chaining 和 try/catch，网页版没 preload 也不会崩

## 🧪 验证

合并后：

\`\`\`bash
npx vite build
CSC_IDENTITY_AUTO_DISCOVERY=false npx electron-builder --win --x64 --publish never
cp -rf dist_electron/win-unpacked/* ./
\`\`\`

启动软件，看侧栏 logo 下方 —— 应该显示 \`v7.0.0\`（或你 package.json 里当前写的版本号）。

以后升版本号只改 \`package.json\` 的 \`version\` 字段就完事了。

## 📝 为什么会变成这样

这是个典型的"早期占位符没清理"问题 —— 大概 v4 或 v5 时期加侧栏 logo 时，随手写了个固定字符串，之后每次升版本只改了 \`package.json\`，没人回来把这行改掉。不是什么架构问题，就是当时没接上动态绑定，然后历次升级也没注意到。

这个 PR 跟 #1 (worldbook 白屏) 是独立的两件事，你可以分开 merge、分开验证。建议先 merge #1（白屏是 P0 阻塞性 bug），再 merge 这个（版本号显示是体验问题）。