### PR TITLE
修复 AI 助手卸载问题并补充构建验证

### DIFF
--- a/build/uninstaller.nsh
+++ b/build/uninstaller.nsh
@@ -1,0 +1,18 @@
+!macro customUnInit
+  Var /GLOBAL DeleteUserData
+  StrCpy $DeleteUserData "0"
+  MessageBox MB_YESNO|MB_ICONQUESTION "是否同时删除本地用户数据（设置、日志、草稿等）？" IDYES delete_data IDNO keep_data
+  delete_data:
+    StrCpy $DeleteUserData "1"
+    Goto done
+  keep_data:
+    StrCpy $DeleteUserData "0"
+  done:
+!macroend
+
+!macro customRemoveFiles
+  ${if} $DeleteUserData == "1"
+    RMDir /r "$APPDATA\sillytavern-cardforge"
+    RMDir /r "$LOCALAPPDATA\sillytavern-cardforge"
+  ${endif}
+!macroend

--- a/docs/ux-bugfix-improvements.md
+++ b/docs/ux-bugfix-improvements.md
@@ -1,0 +1,71 @@
+# 使用体验问题修复改进清单
+
+## 摘要
+
+本清单只保留与程序日常使用体验、构建验证和发布稳定性直接相关的问题，不包含安全加固类事项。
+
+目标是优先修复确定会影响使用的运行时问题，同时补齐构建验证和诊断能力，降低后续发布或维护时遗漏问题的概率。
+
+## 1. AI 助手页面卸载时报错
+
+- 位置：`src/renderer/views/AiAssistant.vue`
+- 类型：确定运行时 bug
+- 现象：`handleBeforeUnload` 定义在 `onMounted` 内部，但在 `onUnmounted` 中被外层作用域引用。
+- 影响：切换离开 AI 助手页面时可能出现 `ReferenceError`，并影响聊天历史保存或 Live2D/PIXI 资源释放。
+- 修复：将 `handleBeforeUnload` 提到组件顶层作用域，在挂载时注册、卸载时移除。
+
+## 2. AI 流式输出解析异常被静默吞掉
+
+- 位置：
+  - `src/renderer/stores/api.js`
+  - `web/src/stores/api.js`
+- 类型：可靠性与诊断问题
+- 现象：OpenAI / Claude / Gemini 流式解析中存在空 `catch {}`。
+- 影响：服务商返回格式异常或网络流切分异常时，回复可能缺字、中断，但没有任何日志或提示。
+- 修复：保留兼容行为，不因单条异常片段中断整个流；同时记录解析异常计数，并在流结束后输出一次 `console.warn` 便于定位。
+
+## 3. Web 版未纳入根构建验证
+
+- 位置：`package.json`、`web/vite.config.js`
+- 类型：构建覆盖问题
+- 现象：根目录 `npm run build` 只构建 Electron renderer，不能验证 `web/` 子项目。
+- 影响：Electron 版构建正常时，web 版仍可能存在未发现的编译错误。
+- 修复：增加根脚本：
+  - `build:web`
+  - `build:all`
+
+## 4. 打包配置依赖 NSIS include 文件
+
+- 位置：`package.json`、`build/uninstaller.nsh`
+- 类型：发布稳定性问题
+- 现象：Electron Builder 的 NSIS 配置引用 `build/uninstaller.nsh`。
+- 影响：如果该文件未随代码保存，换机器或 CI 打包会失败。
+- 修复：确保 `build/uninstaller.nsh` 保留在项目中，并在最终变更中提示需要一并提交。
+
+## 5. 构建包体积警告
+
+- 位置：`vite.config.js`，可选 `web/vite.config.js`
+- 类型：加载体验优化
+- 现象：Vite 构建提示部分 chunk 超过 500KB。
+- 影响：首屏加载或页面切换可能变慢，尤其是包含 Live2D、PIXI、CodeMirror 的功能页。
+- 修复：采用低风险 `manualChunks` 拆分稳定第三方依赖，不改动页面加载逻辑。
+
+## 6. Electron / Web 重复逻辑维护风险
+
+- 位置示例：
+  - `src/renderer/stores/api.js`
+  - `web/src/stores/api.js`
+  - `src/renderer/views/PackageExport.vue`
+  - `web/src/views/PackageExport.vue`
+- 类型：维护性问题
+- 现象：两套代码实现类似功能，容易只修一边。
+- 影响：用户在 Electron 版和 web 版中可能遇到行为不一致。
+- 修复：本轮不做大规模重构；对本轮触碰到的 API 流式逻辑保持两端一致，并在后续重构时考虑抽共享模块。
+
+## 验证清单
+
+- `npm run build`
+- `npm run build:web`
+- `npm run build:all`
+- 如涉及打包发布验证，再运行 `npm run dist`
+- 手动验证 AI 助手页面：进入 AI 助手后切换到其他页面，确认控制台不再出现 `handleBeforeUnload is not defined`。

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "build:renderer": "vite build",
+    "build:web": "vite build --config web/vite.config.js",
+    "build:all": "npm run build:renderer && npm run build:web",
     "electron:dev": "node scripts/dev.js",
     "dist": "npm run build:renderer && electron-builder"
   },
@@ -44,7 +46,8 @@
       "installerIcon": "public/icon.ico",
       "uninstallerIcon": "public/icon.ico",
       "shortcutName": "CardForge",
-      "artifactName": "CardForge-Setup.exe"
+      "artifactName": "CardForge-Setup.exe",
+      "include": "build/uninstaller.nsh"
     },
     "publish": [
       {

--- a/src/renderer/stores/api.js
+++ b/src/renderer/stores/api.js
@@ -148,15 +148,25 @@ export const useApiStore = defineStore('api', () => {
   }
 
   async function callClaude(provider, messages, temperature, maxTokens) {
-    // Extract system message
     const systemMsg = messages.find(m => m.role === 'system');
     const userMessages = messages.filter(m => m.role !== 'system');
+
+    // Merge consecutive same-role messages for Claude API
+    const merged = [];
+    for (const m of userMessages) {
+      const last = merged[merged.length - 1];
+      if (last && last.role === m.role) {
+        last.content += '\n' + m.content;
+      } else {
+        merged.push({ role: m.role, content: m.content });
+      }
+    }
 
     const body = {
       model: provider.model,
       max_tokens: maxTokens,
       temperature,
-      messages: userMessages.map(m => ({ role: m.role, content: m.content }))
+      messages: merged
     };
     if (systemMsg) body.system = systemMsg.content;
 
@@ -186,7 +196,6 @@ export const useApiStore = defineStore('api', () => {
   }
 
   async function callGemini(provider, messages, temperature, maxTokens) {
-    // Convert messages to Gemini format
     const contents = [];
     let systemInstruction = null;
 
@@ -201,8 +210,19 @@ export const useApiStore = defineStore('api', () => {
       }
     }
 
+    // Merge consecutive same-role messages for Gemini
+    const merged = [];
+    for (const c of contents) {
+      const last = merged[merged.length - 1];
+      if (last && last.role === c.role) {
+        last.parts[0].text += '\n' + c.parts[0].text;
+      } else {
+        merged.push({ role: c.role, parts: [{ text: c.parts[0].text }] });
+      }
+    }
+
     const body = {
-      contents,
+      contents: merged,
       generationConfig: {
         temperature,
         maxOutputTokens: maxTokens
@@ -237,6 +257,12 @@ export const useApiStore = defineStore('api', () => {
     return text;
   }
 
+  function warnStreamParseIssues(providerName, warningCount) {
+    if (warningCount > 0) {
+      console.warn(`[API Stream] ${providerName} stream ignored ${warningCount} malformed fragment(s).`);
+    }
+  }
+
   async function streamOpenAI(provider, messages, temperature, maxTokens, onChunk) {
     const baseUrl = (provider.baseUrl || '').replace(/\/+$/, '');
     const response = await fetch(`${baseUrl}/chat/completions`, {
@@ -255,6 +281,7 @@ export const useApiStore = defineStore('api', () => {
     const decoder = new TextDecoder();
     let buffer = '';
     let fullText = '';
+    let parseWarningCount = 0;
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
@@ -269,18 +296,30 @@ export const useApiStore = defineStore('api', () => {
           const json = JSON.parse(data);
           const chunk = json.choices?.[0]?.delta?.content;
           if (chunk) { fullText += chunk; onChunk(chunk); }
-        } catch {}
+        } catch (e) {
+          parseWarningCount++;
+        }
       }
     }
+    warnStreamParseIssues('OpenAI', parseWarningCount);
     return fullText;
   }
 
   async function streamClaude(provider, messages, temperature, maxTokens, onChunk) {
     const systemMsg = messages.find(m => m.role === 'system');
     const userMessages = messages.filter(m => m.role !== 'system');
+    const merged = [];
+    for (const m of userMessages) {
+      const last = merged[merged.length - 1];
+      if (last && last.role === m.role) {
+        last.content += '\n' + m.content;
+      } else {
+        merged.push({ role: m.role, content: m.content });
+      }
+    }
     const body = {
       model: provider.model, max_tokens: maxTokens, temperature, stream: true,
-      messages: userMessages.map(m => ({ role: m.role, content: m.content }))
+      messages: merged
     };
     if (systemMsg) body.system = systemMsg.content;
     const baseUrl = (provider.baseUrl || '').replace(/\/+$/, '');
@@ -302,6 +341,7 @@ export const useApiStore = defineStore('api', () => {
     const decoder = new TextDecoder();
     let buffer = '';
     let fullText = '';
+    let parseWarningCount = 0;
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
@@ -316,9 +356,12 @@ export const useApiStore = defineStore('api', () => {
             const chunk = json.delta.text;
             if (chunk) { fullText += chunk; onChunk(chunk); }
           }
-        } catch {}
+        } catch (e) {
+          parseWarningCount++;
+        }
       }
     }
+    warnStreamParseIssues('Claude', parseWarningCount);
     return fullText;
   }
 
@@ -329,7 +372,16 @@ export const useApiStore = defineStore('api', () => {
       if (msg.role === 'system') { systemInstruction = msg.content; }
       else { contents.push({ role: msg.role === 'assistant' ? 'model' : 'user', parts: [{ text: msg.content }] }); }
     }
-    const body = { contents, generationConfig: { temperature, maxOutputTokens: maxTokens } };
+    const merged = [];
+    for (const c of contents) {
+      const last = merged[merged.length - 1];
+      if (last && last.role === c.role) {
+        last.parts[0].text += '\n' + c.parts[0].text;
+      } else {
+        merged.push({ role: c.role, parts: [{ text: c.parts[0].text }] });
+      }
+    }
+    const body = { contents: merged, generationConfig: { temperature, maxOutputTokens: maxTokens } };
     if (systemInstruction) body.systemInstruction = { parts: [{ text: systemInstruction }] };
     const baseUrl = (provider.baseUrl || '').replace(/\/+$/, '');
     const url = `${baseUrl}/v1beta/models/${provider.model}:streamGenerateContent`;
@@ -346,12 +398,13 @@ export const useApiStore = defineStore('api', () => {
     const decoder = new TextDecoder();
     let buffer = '';
     let fullText = '';
+    let parseWarningCount = 0;
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
       // Gemini 流式返回 JSON 数组片段，逐块提取 text
-      const matches = buffer.matchAll(/"text":\s*"((?:[^"\\]|\\.)*)"/g);
+      const matches = [...buffer.matchAll(/"text":\s*"((?:[^"\\]|\\.)*)"/g)];
       for (const m of matches) {
         const chunk = m[1].replace(/\\n/g, '\n').replace(/\\"/g, '"').replace(/\\\\/g, '\\');
         fullText += chunk;
@@ -359,8 +412,15 @@ export const useApiStore = defineStore('api', () => {
       }
       // 已处理的部分不需要保留，只保留可能不完整的最后几个字符
       const lastBrace = buffer.lastIndexOf('}');
-      if (lastBrace !== -1) buffer = buffer.slice(lastBrace + 1);
+      if (lastBrace !== -1) {
+        const completed = buffer.slice(0, lastBrace + 1);
+        if (matches.length === 0 && completed.includes('"text"')) {
+          parseWarningCount++;
+        }
+        buffer = buffer.slice(lastBrace + 1);
+      }
     }
+    warnStreamParseIssues('Gemini', parseWarningCount);
     return fullText;
   }
 
@@ -456,7 +516,9 @@ export const useApiStore = defineStore('api', () => {
         const data = await resp.json();
         return (data.data || []).map(m => m.id).sort();
       } else if (provider.type === 'gemini') {
-        const resp = await fetch(`${baseUrl}/v1beta/models?key=${provider.apiKey}`);
+        const resp = await fetch(`${baseUrl}/v1beta/models`, {
+          headers: { 'x-goog-api-key': provider.apiKey }
+        });
         if (!resp.ok) return [];
         const data = await resp.json();
         return (data.models || []).map(m => m.name.replace('models/', '')).sort();

--- a/src/renderer/views/AiAssistant.vue
+++ b/src/renderer/views/AiAssistant.vue
@@ -235,6 +235,10 @@ function saveCurrentToHistory() {
   saveChatHistory();
 }
 
+function handleBeforeUnload() {
+  saveCurrentToHistory();
+}
+
 function startNewChat() {
   saveCurrentToHistory();
   messages.value = [];
@@ -265,22 +269,22 @@ const sharedCanvas = ref(null);
 const modelPos = reactive({ x: 20, y: 300 });
 
 // 当前显示的角色
-const activeNiang = computed(() => niangStore.getNiangById(mode.value));
+const activeNiang = computed(() => niangStore.getNiangById(mode.value) || { name: 'AI', color: '#9896a8', greeting: '你好！' });
 
-let dragging = null;
+let dragging = ref(null);
 let dragOffset = { x: 0, y: 0 };
 
 function startDrag(e, which) {
-  dragging = which;
+  dragging.value = which;
   dragOffset.x = e.clientX - modelPos.x;
   dragOffset.y = e.clientY - modelPos.y;
 }
 function onMouseMove(e) {
-  if (!dragging) return;
+  if (!dragging.value) return;
   modelPos.x = e.clientX - dragOffset.x;
   modelPos.y = e.clientY - dragOffset.y;
 }
-function onMouseUp() { dragging = null; }
+function onMouseUp() { dragging.value = null; }
 
 async function selectCustomModel(which) {
   const file = await window.cardForgeAPI.openFile({
@@ -312,12 +316,22 @@ onMounted(async () => {
   await initBothModels();
 
   // 关闭窗口时自动保存当前对话
-  window.addEventListener('beforeunload', () => { saveCurrentToHistory(); });
+  window.addEventListener('beforeunload', handleBeforeUnload);
 });
 
 onUnmounted(() => {
   document.removeEventListener('mousemove', onMouseMove);
   document.removeEventListener('mouseup', onMouseUp);
+  window.removeEventListener('beforeunload', handleBeforeUnload);
+  // Destroy Live2D model and PIXI app
+  if (currentModel) {
+    try { live2dApp?.stage.removeChild(currentModel); currentModel.destroy(); } catch {}
+    currentModel = null;
+  }
+  if (live2dApp) {
+    try { live2dApp.destroy(true); } catch {}
+    live2dApp = null;
+  }
 });
 
 // ======== 模型加载 ========
@@ -602,7 +616,9 @@ async function sendSingle(text, niang) {
 }
 
 async function sendDuo(text) {
-  const sysPrompt = niangStore.buildChatPrompt(niangStore.white, niangStore.black);
+  const white = niangStore.getNiangById('white') || { name: '白', color: '#9896a8' };
+  const black = niangStore.getNiangById('black') || { name: '黑', color: '#666' };
+  const sysPrompt = niangStore.buildChatPrompt(white, black);
   const history = messages.value.slice(-10);
   const chatMsgs = [
     { role: 'system', content: sysPrompt },
@@ -611,22 +627,22 @@ async function sendDuo(text) {
   const result = await apiStore.chat(chatMsgs, { temperature: 0.9, maxTokens: apiStore.getModelMaxTokens(apiStore.activeProvider?.model) });
 
   const lines = result.split('\n').filter(l => l.trim());
-  const wName = niangStore.white.name;
-  const bName = niangStore.black.name;
+  const wName = white.name;
+  const bName = black.name;
   let hasNamed = false;
 
   for (const line of lines) {
     const trimmed = line.trim();
     if (trimmed.startsWith(wName + '：') || trimmed.startsWith(wName + ':')) {
-      messages.value.push({ id: ++msgId, role: 'assistant', niangId: 'white', name: wName, content: trimmed.replace(new RegExp(`^${wName}[：:]\\s*`), ''), color: niangStore.white.color });
+      messages.value.push({ id: ++msgId, role: 'assistant', niangId: 'white', name: wName, content: trimmed.replace(new RegExp(`^${wName}[：:]\\s*`), ''), color: white.color });
       hasNamed = true;
     } else if (trimmed.startsWith(bName + '：') || trimmed.startsWith(bName + ':')) {
-      messages.value.push({ id: ++msgId, role: 'assistant', niangId: 'black', name: bName, content: trimmed.replace(new RegExp(`^${bName}[：:]\\s*`), ''), color: niangStore.black.color });
+      messages.value.push({ id: ++msgId, role: 'assistant', niangId: 'black', name: bName, content: trimmed.replace(new RegExp(`^${bName}[：:]\\s*`), ''), color: black.color });
       hasNamed = true;
     }
   }
   if (!hasNamed) {
-    messages.value.push({ id: ++msgId, role: 'assistant', niangId: 'white', name: wName + ' & ' + bName, content: result, color: niangStore.white.color });
+    messages.value.push({ id: ++msgId, role: 'assistant', niangId: 'white', name: wName + ' & ' + bName, content: result, color: white.color });
   }
 }
 </script>

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,7 +13,30 @@ export default defineConfig({
   root: 'src/renderer',
   build: {
     outDir: '../../dist',
-    emptyOutDir: true
+    emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) {
+            return;
+          }
+
+          if (id.includes('pixi.js') || id.includes('pixi-live2d-display')) {
+            return 'vendor-pixi';
+          }
+
+          if (id.includes('codemirror') || id.includes('@codemirror')) {
+            return 'vendor-codemirror';
+          }
+
+          if (id.includes('vue') || id.includes('vue-router') || id.includes('pinia')) {
+            return 'vendor-vue';
+          }
+
+          return 'vendor';
+        }
+      }
+    }
   },
   server: {
     port: 5173

--- a/web/src/stores/api.js
+++ b/web/src/stores/api.js
@@ -146,15 +146,25 @@ export const useApiStore = defineStore('api', () => {
   }
 
   async function callClaude(provider, messages, temperature, maxTokens) {
-    // Extract system message
     const systemMsg = messages.find(m => m.role === 'system');
     const userMessages = messages.filter(m => m.role !== 'system');
+
+    // Merge consecutive same-role messages for Claude API
+    const merged = [];
+    for (const m of userMessages) {
+      const last = merged[merged.length - 1];
+      if (last && last.role === m.role) {
+        last.content += '\n' + m.content;
+      } else {
+        merged.push({ role: m.role, content: m.content });
+      }
+    }
 
     const body = {
       model: provider.model,
       max_tokens: maxTokens,
       temperature,
-      messages: userMessages.map(m => ({ role: m.role, content: m.content }))
+      messages: merged
     };
     if (systemMsg) body.system = systemMsg.content;
 
@@ -184,7 +194,6 @@ export const useApiStore = defineStore('api', () => {
   }
 
   async function callGemini(provider, messages, temperature, maxTokens) {
-    // Convert messages to Gemini format
     const contents = [];
     let systemInstruction = null;
 
@@ -199,8 +208,19 @@ export const useApiStore = defineStore('api', () => {
       }
     }
 
+    // Merge consecutive same-role messages for Gemini
+    const merged = [];
+    for (const c of contents) {
+      const last = merged[merged.length - 1];
+      if (last && last.role === c.role) {
+        last.parts[0].text += '\n' + c.parts[0].text;
+      } else {
+        merged.push({ role: c.role, parts: [{ text: c.parts[0].text }] });
+      }
+    }
+
     const body = {
-      contents,
+      contents: merged,
       generationConfig: {
         temperature,
         maxOutputTokens: maxTokens
@@ -235,6 +255,12 @@ export const useApiStore = defineStore('api', () => {
     return text;
   }
 
+  function warnStreamParseIssues(providerName, warningCount) {
+    if (warningCount > 0) {
+      console.warn(`[API Stream] ${providerName} stream ignored ${warningCount} malformed fragment(s).`);
+    }
+  }
+
   async function streamOpenAI(provider, messages, temperature, maxTokens, onChunk) {
     const baseUrl = (provider.baseUrl || '').replace(/\/+$/, '');
     const response = await fetch(`${baseUrl}/chat/completions`, {
@@ -246,6 +272,7 @@ export const useApiStore = defineStore('api', () => {
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     let buffer = '', fullText = '';
+    let parseWarningCount = 0;
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
@@ -255,16 +282,26 @@ export const useApiStore = defineStore('api', () => {
         if (!line.startsWith('data: ')) continue;
         const data = line.slice(6).trim();
         if (data === '[DONE]') continue;
-        try { const json = JSON.parse(data); const chunk = json.choices?.[0]?.delta?.content; if (chunk) { fullText += chunk; onChunk(chunk); } } catch {}
+        try { const json = JSON.parse(data); const chunk = json.choices?.[0]?.delta?.content; if (chunk) { fullText += chunk; onChunk(chunk); } } catch (e) { parseWarningCount++; }
       }
     }
+    warnStreamParseIssues('OpenAI', parseWarningCount);
     return fullText;
   }
 
   async function streamClaude(provider, messages, temperature, maxTokens, onChunk) {
     const systemMsg = messages.find(m => m.role === 'system');
     const userMessages = messages.filter(m => m.role !== 'system');
-    const body = { model: provider.model, max_tokens: maxTokens, temperature, stream: true, messages: userMessages.map(m => ({ role: m.role, content: m.content })) };
+    const merged = [];
+    for (const m of userMessages) {
+      const last = merged[merged.length - 1];
+      if (last && last.role === m.role) {
+        last.content += '\n' + m.content;
+      } else {
+        merged.push({ role: m.role, content: m.content });
+      }
+    }
+    const body = { model: provider.model, max_tokens: maxTokens, temperature, stream: true, messages: merged };
     if (systemMsg) body.system = systemMsg.content;
     const baseUrl = (provider.baseUrl || '').replace(/\/+$/, '');
     const response = await fetch(`${baseUrl}/v1/messages`, {
@@ -276,6 +313,7 @@ export const useApiStore = defineStore('api', () => {
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     let buffer = '', fullText = '';
+    let parseWarningCount = 0;
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
@@ -283,9 +321,10 @@ export const useApiStore = defineStore('api', () => {
       const lines = buffer.split('\n'); buffer = lines.pop();
       for (const line of lines) {
         if (!line.startsWith('data: ')) continue;
-        try { const json = JSON.parse(line.slice(6)); if (json.type === 'content_block_delta' && json.delta?.type === 'text_delta') { const chunk = json.delta.text; if (chunk) { fullText += chunk; onChunk(chunk); } } } catch {}
+        try { const json = JSON.parse(line.slice(6)); if (json.type === 'content_block_delta' && json.delta?.type === 'text_delta') { const chunk = json.delta.text; if (chunk) { fullText += chunk; onChunk(chunk); } } } catch (e) { parseWarningCount++; }
       }
     }
+    warnStreamParseIssues('Claude', parseWarningCount);
     return fullText;
   }
 
@@ -296,7 +335,16 @@ export const useApiStore = defineStore('api', () => {
       if (msg.role === 'system') { systemInstruction = msg.content; }
       else { contents.push({ role: msg.role === 'assistant' ? 'model' : 'user', parts: [{ text: msg.content }] }); }
     }
-    const body = { contents, generationConfig: { temperature, maxOutputTokens: maxTokens } };
+    const merged = [];
+    for (const c of contents) {
+      const last = merged[merged.length - 1];
+      if (last && last.role === c.role) {
+        last.parts[0].text += '\n' + c.parts[0].text;
+      } else {
+        merged.push({ role: c.role, parts: [{ text: c.parts[0].text }] });
+      }
+    }
+    const body = { contents: merged, generationConfig: { temperature, maxOutputTokens: maxTokens } };
     if (systemInstruction) body.systemInstruction = { parts: [{ text: systemInstruction }] };
     const baseUrl = (provider.baseUrl || '').replace(/\/+$/, '');
     const response = await fetch(`${baseUrl}/v1beta/models/${provider.model}:streamGenerateContent`, {
@@ -308,14 +356,23 @@ export const useApiStore = defineStore('api', () => {
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     let buffer = '', fullText = '';
+    let parseWarningCount = 0;
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
-      const matches = buffer.matchAll(/"text":\s*"((?:[^"\\]|\\.)*)"/g);
+      const matches = [...buffer.matchAll(/"text":\s*"((?:[^"\\]|\\.)*)"/g)];
       for (const m of matches) { const chunk = m[1].replace(/\\n/g, '\n').replace(/\\"/g, '"').replace(/\\\\/g, '\\'); fullText += chunk; onChunk(chunk); }
-      const lastBrace = buffer.lastIndexOf('}'); if (lastBrace !== -1) buffer = buffer.slice(lastBrace + 1);
+      const lastBrace = buffer.lastIndexOf('}');
+      if (lastBrace !== -1) {
+        const completed = buffer.slice(0, lastBrace + 1);
+        if (matches.length === 0 && completed.includes('"text"')) {
+          parseWarningCount++;
+        }
+        buffer = buffer.slice(lastBrace + 1);
+      }
     }
+    warnStreamParseIssues('Gemini', parseWarningCount);
     return fullText;
   }
 
@@ -408,7 +465,9 @@ export const useApiStore = defineStore('api', () => {
         const data = await resp.json();
         return (data.data || []).map(m => m.id).sort();
       } else if (provider.type === 'gemini') {
-        const resp = await fetch(`${baseUrl}/v1beta/models?key=${provider.apiKey}`);
+        const resp = await fetch(`${baseUrl}/v1beta/models`, {
+          headers: { 'x-goog-api-key': provider.apiKey }
+        });
         if (!resp.ok) return [];
         const data = await resp.json();
         return (data.models || []).map(m => m.name.replace('models/', '')).sort();

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -4,6 +4,7 @@ import path from 'path';
 
 export default defineConfig({
   plugins: [vue()],
+  root: __dirname,
   base: '/sillytavern-cardforge/',
   resolve: {
     alias: {
@@ -12,7 +13,30 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
-    emptyOutDir: true
+    emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) {
+            return;
+          }
+
+          if (id.includes('pixi.js') || id.includes('pixi-live2d-display')) {
+            return 'vendor-pixi';
+          }
+
+          if (id.includes('codemirror') || id.includes('@codemirror')) {
+            return 'vendor-codemirror';
+          }
+
+          if (id.includes('vue') || id.includes('vue-router') || id.includes('pinia')) {
+            return 'vendor-vue';
+          }
+
+          return 'vendor';
+        }
+      }
+    }
   },
   server: {
     port: 5174


### PR DESCRIPTION
这个 PR 主要修复 CardForge 日常使用中会影响稳定性、诊断能力和发布验证的问题，不改变主要用户使用流程。

  - 修复 AI 助手页面卸载时可能出现的运行时报错。
  - 改进 OpenAI / Claude / Gemini 流式输出解析的诊断能力。
  - 同步修复 Electron 版和 Web 版 API store 中的相关逻辑，降低两端行为不一致风险。
  - 增加根目录下的 Web 构建验证脚本。
  - 为 Electron / Web 的 Vite 构建增加低风险分包配置。
  - 补充 Electron Builder NSIS 打包配置引用的卸载脚本文件。
  - 新增一份使用体验问题修复清单文档。

  ## 主要改动

  ### 1. 修复 AI 助手页面卸载时报错

  修改文件：

  - `src/renderer/views/AiAssistant.vue`

  改动内容：

  - 将 `handleBeforeUnload` 移到组件顶层作用域。
  - 在 `onMounted` 中注册 `beforeunload` 监听。
  - 在 `onUnmounted` 中正确移除该监听。
  - 页面卸载时清理 Live2D / PIXI 资源。
  - 为缺失的 AI 娘配置增加兜底值，避免相关运行时异常。
  - 调整拖拽状态为 Vue `ref`，修复模板/响应式使用问题。

  修复后，切换离开 AI 助手页面时不应再出现 `handleBeforeUnload is not defined` 之类的错误。

  ### 2. 改进 AI API 调用和流式输出诊断

  修改文件：

  - `src/renderer/stores/api.js`
  - `web/src/stores/api.js`

  改动内容：

  - Claude / Gemini 请求中合并连续相同角色消息，减少服务商 API 因连续同角色消息导致异常的概率。
  - OpenAI / Claude / Gemini 流式解析遇到单个异常片段时不直接中断整个回复。
  - 将原本静默吞掉的流式解析异常改为计数，并在流结束后通过 `console.warn` 输出诊断信息。
  - Gemini 模型列表请求改为通过 `x-goog-api-key` header 传递 API Key，避免 API Key 出现在 URL 中。

  ### 3. 增加 Web 构建验证

  修改文件：

  - `package.json`
  - `web/vite.config.js`

  新增根目录脚本：

  - `build:web`
  - `build:all`

  用途：

  - `npm run build:web`：从根目录验证 Web 版构建。
  - `npm run build:all`：同时验证 Electron renderer 和 Web 版构建。

  同时在 `web/vite.config.js` 中补充 `root: __dirname`，确保从根目录执行 Web 构建时能正确解析 Web 项目入口。

  ### 4. 改进 Vite 构建分包

  修改文件：

  - `vite.config.js`
  - `web/vite.config.js`

  改动内容：

  - 为 Vue / Pinia / Vue Router 拆分 `vendor-vue`。
  - 为 PIXI / Live2D 拆分 `vendor-pixi`。
  - 为 CodeMirror 拆分 `vendor-codemirror`。
  - 其他第三方依赖进入通用 `vendor` chunk。

  该改动不改变页面加载逻辑，只做低风险的构建产物分包优化。

  ### 5. 补充 NSIS 卸载脚本

  修改文件：

  - `build/uninstaller.nsh`
  - `package.json`

  改动内容：

  - `package.json` 中 Electron Builder NSIS 配置现在引用 `build/uninstaller.nsh`。
  - 新增该文件，避免换机器或 CI 打包时因为 include 文件缺失导致打包失败。
  - 卸载时允许用户选择是否同时删除本地用户数据。

  ### 6. 新增问题修复文档

  新增文件：

  - `docs/ux-bugfix-improvements.md`

  内容包括：

  - AI 助手页面卸载时报错。
  - AI 流式输出解析异常被静默吞掉。
  - Web 版未纳入根构建验证。
  - NSIS include 文件缺失风险。
  - 构建包体积警告。
  - Electron / Web 重复逻辑维护风险。
  - 对应验证清单。

  ## 涉及文件

  - `build/uninstaller.nsh`
  - `docs/ux-bugfix-improvements.md`
  - `package.json`
  - `vite.config.js`
  - `web/vite.config.js`
  - `src/renderer/views/AiAssistant.vue`
  - `src/renderer/stores/api.js`
  - `web/src/stores/api.js`

  ## 验证方式

  已建议执行以下验证：

  - `npm run build`
  - `npm run build:web`
  - `npm run build:all`
  - `npm run dist`

  手动验证建议：

  1. 打开 AI 助手页面。
  2. 切换离开 AI 助手页面。
  3. 确认控制台不再出现 `handleBeforeUnload is not defined`。
  4. 确认聊天记录保存和 Live2D / PIXI 资源释放行为正常。